### PR TITLE
Removed deprecated -f flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ default: build
 
 build:
 	docker build -t $(DOCKER_IMAGE_TAGNAME) .
-	docker tag -f $(DOCKER_IMAGE_TAGNAME) $(DOCKER_IMAGE_NAME):latest
+	docker tag $(DOCKER_IMAGE_TAGNAME) $(DOCKER_IMAGE_NAME):latest
 
 push:
 	docker push $(DOCKER_IMAGE_NAME)


### PR DESCRIPTION
-f flag for docker tag is gone in newer versions of docker. See https://docs.docker.com/engine/deprecated/#containersid-or-namecopy-endpoint.